### PR TITLE
Add a new linear runtime method for get_n1_n2

### DIFF
--- a/ddks/methods/ddks.py
+++ b/ddks/methods/ddks.py
@@ -214,6 +214,9 @@ class ddKS(object):
 
     def get_n1_n2_linear(self, delta, m_1, m_2):
         """An implementation of get_n1_n2 with linear runtime and worst-case linear memory. Should be used for large m_1 * m_2."""
+        flip = m1 > m2
+        if flip: m1, m2 = m2, m1
+
         n_1s, n_2s = [], []
         for x in range(m_1 + 1):  # consider integers \in [0, m1]
             _x = x * m_2 / m_1
@@ -228,7 +231,10 @@ class ddKS(object):
                     n_1s.append(x)
                     n_2s.append(y)
 
-        return np.array(n_1s), np.array(n_2s)
+        if flip:
+            return np.array(n_2s), np.array(n_1s)
+        else:
+            return np.array(n_1s), np.array(n_2s)
 
     def p_delta(self, delta, m_1, m_2, lam):
         _p_delta = 0.0

--- a/ddks/methods/ddks.py
+++ b/ddks/methods/ddks.py
@@ -199,6 +199,10 @@ class ddKS(object):
         #idx = np.logical_and(idx, n_1 >= 0)
         #n_1 = n_1[idx]
         #n_2 = n_2[idx]
+
+        if m_1 * m_2 > 250:
+            return self.get_n1_n2_linear(delta, m_1, m_2)
+
         r_1 = np.arange(0.0, m_1 + 0.5) / m_1
         r_2 = np.arange(0.0, m_2 + 0.5) / m_2
         X, Y = np.meshgrid(r_1, r_2)
@@ -207,6 +211,24 @@ class ddKS(object):
         n_1s = m_1 * r_1[idx[:, 1]]
         n_2s = m_2 * r_2[idx[:, 0]]
         return n_1s, n_2s
+
+    def get_n1_n2_linear(self, delta, m_1, m_2):
+        """An implementation of get_n1_n2 with linear runtime and worst-case linear memory. Should be used for large m_1 * m_2."""
+        n_1s, n_2s = [], []
+        for x in range(m_1 + 1):  # consider integers \in [0, m1]
+            _x = x * m_2 / m_1
+            _delta = m_2 * delta
+
+            for sign in [-1, +1]:
+                y = round(_x + sign * _delta)
+                if y < 0: continue
+                if y > m_2: continue
+                if abs(abs( x / m_1 - y / m_2 ) - delta) < 1e-6:
+                    # keep if still close enough after rounding
+                    n_1s.append(x)
+                    n_2s.append(y)
+
+        return np.array(n_1s), np.array(n_2s)
 
     def p_delta(self, delta, m_1, m_2, lam):
         _p_delta = 0.0

--- a/ddks/methods/ddks.py
+++ b/ddks/methods/ddks.py
@@ -200,7 +200,7 @@ class ddKS(object):
         #n_1 = n_1[idx]
         #n_2 = n_2[idx]
 
-        if m_1 * m_2 > 250:
+        if m_1 * m_2 > 20_000:
             return self.get_n1_n2_linear(delta, m_1, m_2)
 
         r_1 = np.arange(0.0, m_1 + 0.5) / m_1

--- a/ddks/methods/ddks.py
+++ b/ddks/methods/ddks.py
@@ -214,8 +214,8 @@ class ddKS(object):
 
     def get_n1_n2_linear(self, delta, m_1, m_2):
         """An implementation of get_n1_n2 with linear runtime and worst-case linear memory. Should be used for large m_1 * m_2."""
-        flip = m1 > m2
-        if flip: m1, m2 = m2, m1
+        flip = m_1 > m_2
+        if flip: m_1, m_2 = m_2, m_1
 
         n_1s, n_2s = [], []
         for x in range(m_1 + 1):  # consider integers \in [0, m1]


### PR DESCRIPTION
The method `get_n1_n2` current has guaranteed quadratic (O(m1 * m2)) runtime and memory usage. For large values of m1 and m2, the memory usage in particular can become a massive problem. I've added a secondary implementation that is linear in runtime, O(min(m1, m2)), and worst-case linear in memory. 

The idea is that we have two arrays, `r1 = [0, 1, 2, ..., m1] / m1` and `r2 = [0, 1, 2, ..., m2] / m2`, and we want all pairs of those integers for which r1[i] and r2[j] differ by delta (or close enough). The current implementation populates an m1-by-m2 array with all pairwise differences of r1 and r2 and uses argwhere to find the indices where the difference is close to delta. Instead, I...

- iterate over `x` in [0, 1, 2, ..., m1]
- analytically compute the two solutions `y` to the equation `| x/m1 - y/m2 | = delta`
- round these solutions to integers
- for each solution
    - ensure `y` lies in the interval [0, m2]
    - test whether the equality with delta still holds (to within 1e-6) for each solution
- if so, save the pair `(x, y)`. else, continue

This gives equivalent results to the current implementation, with two exceptions:
- the order of the results is often different
- the new method is guaranteed to return ints, where the current implementation returns floats that are not always exactly equal to integers

This implementation is slower for small values of m1 and m2, but is noticeably faster when the values become large. For example, 

```
_ddks = ddks.methods.ddKS()
n_1, n_2 = 100, 1000
_ddks.p(torch.rand(n_1, 3), torch.rand(n_2, 3))
```

took about 18 minutes to run with the current implementation, compared to 8 minutes with the new implementation.

I've added a switch to `get_n1_n2` to use the linear implementation when `m1 * m2 > 20_000`. I picked this number because, using the above code block, `n_1, n_2 = 100, 100` seemed to be faster for the current implementation, `n_1, n_2 = 100, 200` seemed to take the same amount of time with both implementations, and `n_1, n_2 = 100, 500` seemed to be faster with the linear implementation.

The method `p` itself seems to be about O(m^4) (with m ~ m1 + m2); the linear `get_n1_n2` reduces this to O(m^3).